### PR TITLE
Restore compatibility w/ 5.8.0 and older clients

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,6 @@
 local get_connected_players = minetest.get_connected_players
 local lastdir = {}
+local basepos = vector.new(0, 6.35, 0)
 
 minetest.register_globalstep(function()
 	for _, player in pairs(get_connected_players()) do
@@ -9,9 +10,13 @@ minetest.register_globalstep(function()
 		if (lastdir[pname] or 0) ~= ldeg then
 			lastdir[pname] = ldeg
 			player:set_bone_override("Head", {
+				position = {
+					vec = basepos,
+					absolute = true
+				},
 				rotation = {
 					vec = {x = ldeg, y = 0, z = 0},
-					interpolation = 0.14,
+					interpolation = 0.09,
 				}
 			})
 		end


### PR DESCRIPTION
Commit https://github.com/LoneWolfHT/headanim/commit/d7839acfdc896339acdd2c466313fcb01aa671b2 broke headanim for older clients (5.8.0 and older).

This PR fixes that by following the docs' compatibility note https://github.com/minetest/minetest/blob/52a6673dab08800df0ef8f6403d9c58489764722/doc/lua_api.md?plain=1#L8291-L8292

Related: https://github.com/Archtec-io/bugtracker/issues/214

Screenshot from 5.7.0 client w/o patch
![image](https://github.com/user-attachments/assets/6ba02899-b6d4-49bb-bc31-4025306587d2)
