### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,5 @@
 local get_connected_players = minetest.get_connected_players
 local lastdir = {}
-local basepos = vector.new(0, 6.35, 0)
 
 minetest.register_globalstep(function()
 	for _, player in pairs(get_connected_players()) do
@@ -10,10 +9,6 @@ minetest.register_globalstep(function()
 		if (lastdir[pname] or 0) ~= ldeg then
 			lastdir[pname] = ldeg
 			player:set_bone_override("Head", {
-				position = {
-					vec = basepos,
-					absolute = true
-				},
 				rotation = {
 					vec = {x = ldeg, y = 0, z = 0},
 					interpolation = 0.09,


### PR DESCRIPTION
removed position setting so that head stays at original position, as it appears sunken in some clients.

Note: readme states that 5.3 is required when it is really 5.9